### PR TITLE
inverted twitter:image and og:image

### DIFF
--- a/ImageResolver.js
+++ b/ImageResolver.js
@@ -283,15 +283,16 @@ OpengraphResolver.prototype.resolve = function(url, clbk) {
                 //@FIXME: remove dependency on WebpageResolver
                 tag = WebpageResolver.prototype._parseTag(meta[i]);
 
-                if (tag.attributes.property && tag.attributes.property === 'og:image' && tag.attributes.content) {
-                    image = tag.attributes.content;
-                    break;
-                }
-
                 if (tag.attributes.name && tag.attributes.name === 'twitter:image' && tag.attributes.value) {
                     image = tag.attributes.value;
                     break;
                 }
+                
+                if (tag.attributes.property && tag.attributes.property === 'og:image' && tag.attributes.content) {
+                    image = tag.attributes.content;
+                    break;
+                }
+                
             }
             clbk(image);
             return;


### PR DESCRIPTION
As most of the time the twitter:image is bigger than the og:image (check the official specifications), is better to check for the twitter card image before the tiny facebook one.
