### PR TITLE
support return an array of images

### DIFF
--- a/src/ImageResolver.js
+++ b/src/ImageResolver.js
@@ -52,10 +52,20 @@ ImageResolver.prototype.resolve = function(url, clbk) {
 
     var callback = function( image ) {
         if ( image ) {
-            clbk( {
-                'url': url,
-                'image': image
-            } );
+            var images = [];
+            if ( image.constructor === Array ) {
+                images = image.slice(1);
+                image = image[0];
+            }
+            if ( image ) {
+                clbk( {
+                    'url': url,
+                    'image': image,
+                    'images': images
+                } );
+            } else {
+                clbk( null );
+            }
             return;
         } else {
             clbk( null );

--- a/tests/node/spec/MultiImageSpec.js
+++ b/tests/node/spec/MultiImageSpec.js
@@ -1,0 +1,39 @@
+var ImageResolver = require('../../../src/ImageResolver');
+
+var MultiImagePlugin = function(data) {
+    var plugin = {};
+    plugin.resolve = function(url, clbk, options, utils) {
+        clbk(data);
+        return;
+    };
+    return plugin;
+};
+
+describe("MultiImage", function(){
+    it("should support image array as resolve result", function(done){
+        var imageresolver = new ImageResolver();
+        var images = ['a', 'b'];
+        imageresolver.register(MultiImagePlugin(images));
+        imageresolver.resolve(
+            "http://multi-image-url.org",
+            function(res){
+                expect(res.image).toEqual(images[0]);
+                expect(res.images).toEqual(images.slice(1));
+                done();
+            }
+        );
+    });
+
+    it("should resolve to null if image array is []", function(done){
+        var imageresolver = new ImageResolver();
+        var images = [];
+        imageresolver.register(MultiImagePlugin(images));
+        imageresolver.resolve(
+            "http://multi-image-url.org",
+            function(res){
+                expect(res).toBe(null);
+                done();
+            }
+        );
+    });
+});


### PR DESCRIPTION
To solve issue #7 .

Update the `resolve` callback to take an result object consist of `url`, `image` (first image), `images` (rest of images) if the return data is not null or empty array.

Add an unit test for a dummy plugin that returns array as data. Didn't get chance to update the real plugins yet.