### PR TITLE
Handling unzip errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+*.swp
+*.swo

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   "dependencies": {
     "htmlparser2": "^3.7.1",
     "request": "^2.36.0",
-    "superagent": "^0.18.0"
+    "superagent": "3.x"
   }
 }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -22,10 +22,11 @@ Utils.prototype.fetch = function( url, success, error ) {
         if ( plugin ) {
             r = r.use( plugin );
         }
+        r.on('error', error);
         r.end( function( err, response ) {
 
             if ( err ) {
-                error();
+                error(err);
                 return;
             }
 


### PR DESCRIPTION
__Problem__
In the case of ill-formed data coming from an url
(in our particular example url is http://www.bhol.co.il/115807/%D7%A8%D7%90%D7%A9-%D7%97%D7%95%D7%93%D7%A9-%D7%90%D7%93%D7%A8-%D7%94%D7%9E%D7%A9%D7%98%D7%A8%D7%94-%D7%A2%D7%A6%D7%A8%D7%94-%D7%9E%D7%95%D7%9B%D7%A8%D7%99-%D7%A0%D7%A4%D7%A6%D7%99%D7%9D-%D7%9E%D7%A1%D7%95%D7%9B%D7%A0%D7%99%D7%9D.html),

`superagent` will try to unzip the data, but the unzip procedure will result in `zlib` throwing an Exception.
This Exception will find no handler, so an `uncaughtException` will occur (in the server-side case, that was important to us).

__Expected behavior__
Expected behavior is to get the exception from `zlib` in the provided `error` callback.

The resolution proposed in this pull request is implemented in 2 steps:
1. depend on the latest version of `superagent` (3.x instead of 0.18.x)
2. set the `error` handler for the obtained `Response` instance to the provided `error` callback

Besides the proposed solution, for the sake of consistency, we also feed the `err` caught to the provided `error` callback