### PR TITLE
Removing memleaks + more options for the Utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "vinyl-source-stream": "^0.1.1"
   },
   "dependencies": {
-    "htmlparser2": "^3.7.1",
+    "htmlparser2": "3.x",
     "request": "^2.36.0",
     "superagent": "3.x"
   }

--- a/src/plugins/MimeType.js
+++ b/src/plugins/MimeType.js
@@ -1,28 +1,33 @@
 function MimeType() {
 }
+MimeType.prototype.onSuccess = function(clbk,url,data,response){
+  var contentType = response.type;
+
+  switch (contentType) {
+      case "image/jpeg":
+      case "image/png":
+      case "image/gif":
+      case "image/svg+xml":
+      case "image/bmp":
+      case "image/tiff":
+          clbk(url);
+          break;
+      default:
+          clbk(null);
+  }
+  clbk = null;
+  url = null;
+
+};
+MimeType.prototype.onError = function(clbk){
+  clbk(null);
+  clbk = null;
+};
 MimeType.prototype.resolve = function( url, clbk, options, utils ) {
     utils.fetch(
         url,
-        function onSuccess( data, response ) {
-            var contentType = response.type;
-
-            switch (contentType) {
-                case "image/jpeg":
-                case "image/png":
-                case "image/gif":
-                case "image/svg+xml":
-                case "image/bmp":
-                case "image/tiff":
-                    clbk(url);
-                    break;
-                default:
-                    clbk(null);
-            }
-
-        },
-        function onError() {
-            clbk(null);
-        }
+        this.onSuccess.bind(this,clbk,url),
+        this.onError.bind(this,clbk)
     );
 }
 

--- a/src/plugins/Opengraph.js
+++ b/src/plugins/Opengraph.js
@@ -38,89 +38,102 @@ var tags = [
 
 function Opengraph() {
 }
+Opengraph.prototype.onSuccess = function(url,clbk,data,response){
+  this.parseHTML( data, url, clbk );
+  clbk = null;
+  url = null;
+};
+Opengraph.prototype.onError = function(clbk){
+  clbk(null);
+  clbk = null;
+};
 Opengraph.prototype.resolve = function(url, clbk, options, utils) {
-    var self = this;
 
     utils.fetch(
         url,
-        function onSuccess( data, response ) {
-            self.parseHTML( data, url, clbk, options, utils );
-        },
-        function onError(){
-            clbk(null);
-        }
+        this.onSuccess.bind(this,url,clbk),
+        this.onError.bind(this,clbk)
     );
 };
 
-Opengraph.prototype.parseHTML = function( html, url, clbk, options, utils ) {
-    var domutils = htmlparser.DomUtils;
+Opengraph.prototype.domHandlerJob = function(url,clbk,error,dom){
+  var domutils = htmlparser.DomUtils;
 
-    var handler = new htmlparser.DomHandler( function( error, dom ) {
+  if ( error ) {
+      clbk(null);
+      clbk = null;
+      url = null;
+      return;
+  }
 
-        if ( error ) {
-            clbk(null);
-            return;
-        }
+  var meta = [].concat(
+      domutils.getElementsByTagName('meta', dom, true),
+      domutils.getElementsByTagName('link', dom, true)
+  );
 
-        var meta = [].concat(
-            domutils.getElementsByTagName('meta', dom, true),
-            domutils.getElementsByTagName('link', dom, true)
-        );
+  var images = [];
+  var image;
+  var tag;
 
-        var images = [];
-        var image;
-        var tag;
+  // Find Opengraph tags
+  for (var i=0,l=meta.length; i<l; i++) {
+      tag = meta[i];
+      for (var j=0, m=tags.length; j<m; j++) {
+          if (
+              tag.attribs[tags[j].attribute] &&
+              tag.attribs[tags[j].attribute] === tags[j].name &&
+              tag.attribs[tags[j].value]
+          ) {
+              images.push({
+                  url: tag.attribs[tags[j].value],
+                  type: tags[j].type,
+                  score: 0
+              });
+          }
+      }
+  }
 
-        // Find Opengraph tags
-        for (var i=0,l=meta.length; i<l; i++) {
-            tag = meta[i];
-            for (var j=0, m=tags.length; j<m; j++) {
-                if (
-                    tag.attribs[tags[j].attribute] &&
-                    tag.attribs[tags[j].attribute] === tags[j].name &&
-                    tag.attribs[tags[j].value]
-                ) {
-                    images.push({
-                        url: tag.attribs[tags[j].value],
-                        type: tags[j].type,
-                        score: 0
-                    });
-                }
-            }
-        }
+  // Find best image among candidates
+  if (images.length === 1) {
+      image = images[0].url;
+  } else if (images.length > 1) {
+      for (i=0, l=images.length; i<l; i++) {
+          //Increase score for image containing "large" or "big" in url
+          if (images[i].url.match(/(large|big)/i)) {
+              images[i].score++;
+          }
+          // Increase score for twitter
+          // Websites tend to limit image size to the size of Facebook preview
+          if (images[i].type === 'twitter') {
+              images[i].score++;
+          }
+      }
+      images.sort(function(a,b){
+          return b.score - a.score;
+      });
+      image = images[0].url;
+  }
 
-        // Find best image among candidates
-        if (images.length === 1) {
-            image = images[0].url;
-        } else if (images.length > 1) {
-            for (i=0, l=images.length; i<l; i++) {
-                //Increase score for image containing "large" or "big" in url
-                if (images[i].url.match(/(large|big)/i)) {
-                    images[i].score++;
-                }
-                // Increase score for twitter
-                // Websites tend to limit image size to the size of Facebook preview
-                if (images[i].type === 'twitter') {
-                    images[i].score++;
-                }
-            }
-            images.sort(function(a,b){
-                return b.score - a.score;
-            });
-            image = images[0].url;
-        }
+  if ( image ) {
+      //Resolve relative url
+      if (!image.match(/^http/)) {
+          image = URL.resolve( url, image);
+      }
+      clbk(image);
+  } else {
+      clbk(null);
+  }
 
-        if ( image ) {
-            //Resolve relative url
-            if (!image.match(/^http/)) {
-                image = URL.resolve( url, image);
-            }
-            clbk(image);
-        } else {
-            clbk(null);
-        }
+  clbk = null;
+  url = null;
 
-    } );
+};
+
+Opengraph.prototype.parseHTML = function( html, url, clbk ) {
+
+    var handler = new htmlparser.DomHandler(this.domHandlerJob.bind(this,url,clbk));
+    clbk = null;
+    url = null;
     var parser = new htmlparser.Parser( handler );
     parser.write( html );
     parser.done();


### PR DESCRIPTION
Majority of the proposed PR deals with proper handling of variables so that the garbage collector can easily do its job.

Besides the memleak-removal stuff, we added 2 more options for the Utils instance:

1. `nocache` - if `true`-ish, then the Utils instance will not cache anything (especially important for the case of saving the response from `superagent`, that leads to heavy memory consumption)
2. `timeout` - if present, it will be used against the `superagent` Response, so that problematic links do not take too long to complete