### PR TITLE
Flickr url regex fix

### DIFF
--- a/src/plugins/Flickr.js
+++ b/src/plugins/Flickr.js
@@ -9,7 +9,7 @@ function Flickr(apikey) {
 }
 Flickr.prototype.resolve = function(url, clbk, options, utils) {
     var request = utils.request;
-    var matches = url.match(/http(s*):\/\/www.flickr.com\/photos\/([^\/]*)\/([^\/]*)\/(.*)/) || [];
+    var matches = url.match(/http(s?):\/\/www.flickr.com\/photos\/([^\/]*)\/(\d+)\b/) || [];
     var id;
     var image;
     var api;


### PR DESCRIPTION
This module was rejecting certain urls, for example: https://www.flickr.com/photos/jrfrancis42/13113373634
It assumed it would be followed by "/in/photostream" or at least a slash.

Also made the photo id matching only digits so that it doesn't match something 
like 'https://www.flickr.com/photos/12037949754@N01/sets/'